### PR TITLE
Fix equations in Lemma 1.34 (Gauss)

### DIFF
--- a/lecture1.tex
+++ b/lecture1.tex
@@ -1046,9 +1046,9 @@ over $\mathbb{Q}$, but what's about $x^{100}-2$?
   \begin{proof}
     Let $P = Q R$ over $\mathbb{Q}$. Then
     \begin{eqnarray}
-      Q = m Q_1, Q_1 \in \mathbb{Z}\left[X\right],
+      m Q = Q_1, Q_1 \in \mathbb{Z}\left[X\right],
       \nonumber \\
-      R = n R_1, R_1 \in \mathbb{Z}\left[X\right],
+      n R = R_1, R_1 \in \mathbb{Z}\left[X\right],
       \nonumber
     \end{eqnarray}
     thus


### PR DESCRIPTION
To derive $n m P = Q_1 R_1$ from $P = Q R$, the equations should be $m Q = Q_1$ and $n R = R_1$ instead of $Q = m Q_1$ and $R = n R_1$.