### PR TITLE
Replace equalities with the ones after applying linearity in Lemma 4.4 (About tensor product existence)

### DIFF
--- a/lecture4.tex
+++ b/lecture4.tex
@@ -235,9 +235,9 @@ object exists.
       \nonumber \\
       f'(\delta_{m,n+n'}) = f'(\delta_{m,n} + \delta_{m,n'}),
       \nonumber \\
-      f'(\delta_{am,n}) =  a f'(\delta_{m,n}),
+      f'(\delta_{am,n}) =  f'(a \delta_{m,n}),
       \nonumber \\
-      f'(\delta_{m,an}) = a f'(\delta_{m,n})
+      f'(\delta_{m,an}) = f'(a \delta_{m,n})
       \nonumber
     \end{eqnarray}
 


### PR DESCRIPTION
> Using the fact that $f$ is bilinear we can get
> 
> $f'(\delta_{m+m',n}) = f(m+m', n) = f(m, n) + f(m', n) = f'(\delta_{m,n}) + f'(\delta_{m',n})$.
> 
> With the same approach one can get the following relations
> 
> * $f'(\delta_{m,n+n'}) = f'(\delta_{m,n}) + f'(\delta_{m,n'})$,
> * $f'(\delta_{am,n}) =  a f'(\delta_{m,n})$,
> * $f'(\delta_{m,an}) = a f'(\delta_{m,n})$
> 
> with the $f'$ linearity we have
> 
> * $f'(\delta_{m+m',n}) = f'(\delta_{m,n} + \delta_{m',n})$,
> * $f'(\delta_{m,n+n'}) = f'(\delta_{m,n} + \delta_{m,n'})$,
> * $f'(\delta_{am,n}) =  a f'(\delta_{m,n})$,
> * $f'(\delta_{m,an}) = a f'(\delta_{m,n})$
> 
> The kernel $\ker f' = \mathcal{F}$ thus if we want to have a homomorphism to $P$ we have to replace $\mathcal{E}$ with $\mathcal{E}/\mathcal{F}$ that is also denoted by $M \otimes_A N$.

The two equations $f'(\delta_{am,n}) =  a f'(\delta_{m,n})$ and $f'(\delta_{m,an}) = a f'(\delta_{m,n})$ are unchanged from the first list to the second.

I think that each equation in the second list is derived from the corresponding equation in the first list by applying linearity, e.g. rewriting right hand side of $f'(\delta_{m,n+n'}) = f'(\delta_{m,n}) + f'(\delta_{m,n'})$ to $f'(\delta_{m,n} + \delta_{m,n'})$ using linearity. Therefore, I guess that the right hand sides of the last two equations are intended to be $f'(a \delta_{m,n})$ instead of $a f'(\delta_{m,n})$.

Also, I feel that this change leads to a more direct argument for $\ker f' = \mathcal{F}$.
